### PR TITLE
Don't build wget

### DIFF
--- a/org.videolan.VLC.Plugin.makemkv.json
+++ b/org.videolan.VLC.Plugin.makemkv.json
@@ -15,20 +15,6 @@
   },
   "modules": [
     {
-      "name": "wget",
-      "no-autogen": true,
-      "config-opts": [
-        "--prefix=/app/share/vlc/extra/makemkv"
-      ],
-      "sources": [
-        {
-            "type": "archive",
-            "url": "https://ftp.gnu.org/gnu/wget/wget-1.21.4.tar.gz",
-            "sha256": "81542f5cefb8faacc39bbbc6c82ded80e3e4a88505ae72ea51df27525bcde04c"
-        }
-      ]
-    },
-    {
       "name": "makemkv-bin",
       "buildsystem": "simple",
       "build-commands": [


### PR DESCRIPTION
wget is already included in the runtime

```
$ flatpak --user run --command=bash app/org.videolan.VLC/x86_64/stable
$ wget --version | head -1
GNU Wget2 2.0.1 - multithreaded metalink/file/website downloader
$ which wget
/usr/bin/wget
$ exit
exit
$ wget --version | head -1
GNU Wget 1.21 built on linux-gnu.
```